### PR TITLE
Feature: Public 'scrollToBottom' method

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ Is called when the `onScroll` event is triggered on the wrapper div created by `
 
 Provides `isAtBottom` boolean value as a parameter, which indicates if the scroll is at bottom position, taking `viewableDetectionEpsilon` into account.
 
+## Public Methods
+
+### scrollToBottom
+
+- Signature: `() => void`
+
+Scroll to the bottom
+
 ## For more details
 
 For more details on how to integrate _react-scrollable-feed_ in your application, have a look at the [example](example) folder.

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -7,7 +7,14 @@ export default class App extends Component {
 
   static intervalDelay = 800;
 
+  constructor(props) {
+    super(props);
+
+    this.scrollableRef = React.createRef();
+  }
+
   state = {
+    isAtBottom: true,
     items: [
       this.createItem(),
       this.createItem(),
@@ -16,6 +23,12 @@ export default class App extends Component {
     ],
     interval: undefined,
   };
+
+  updateIsAtBottomState(result) {
+    this.setState({
+      isAtBottom: result
+    });
+  }
 
   createItem() {
     return {
@@ -52,15 +65,22 @@ export default class App extends Component {
     }));
   }
 
+  scrollToBottom() {
+    this.scrollableRef.current.scrollToBottom();
+  }
+
   render() {
-    const { items, interval } = this.state;
+    const { isAtBottom, items, interval } = this.state;
     return (
       <div className="container">
         <div className="row d-flex justify-content-center mt-5">
           <div className="col-md-8">
             <div className="card">
               <div className="card-body scrollable-wrapper pt-0 pb-0 mt-2">
-                <ScrollableFeed>
+                <ScrollableFeed
+                  ref={this.scrollableRef}
+                  onScroll={isAtBottom => this.updateIsAtBottomState(isAtBottom)}
+                >
                   <ul className="list-group list-group-flush">
                     {items.map((item, i) => (
                       <li key={i} className="list-group-item">
@@ -78,6 +98,7 @@ export default class App extends Component {
                 ) : (
                     <button onClick={() => this.resume()} type="button" className="btn btn-primary m-2">Autoplay</button>
                   )}
+                <button onClick={() => this.scrollToBottom()} disabled={isAtBottom} type="button" className="btn btn-primary m-2">Scroll to Bottom</button>
                 <button onClick={() => this.clear()} type="button" className="btn btn-primary m-2">Clear</button>
               </div>
             </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,7 +104,6 @@ class ScrollableFeed extends React.Component<ScrollableFeedProps> {
     return childTopIsViewable && childBottomIsViewable;
   }
 
-
   /**
    * Fires the onScroll event, sending isAtBottom boolean as its first parameter
    */
@@ -113,6 +112,15 @@ class ScrollableFeed extends React.Component<ScrollableFeedProps> {
     if (onScroll && this.bottomRef.current && this.wrapperRef.current) {
       const isAtBottom = ScrollableFeed.isViewable(this.wrapperRef.current, this.bottomRef.current, viewableDetectionEpsilon!);
       onScroll(isAtBottom);
+    }
+  }
+
+  /**
+   * Scroll to the bottom
+   */
+  public scrollToBottom(): void {
+    if (this.bottomRef.current && this.wrapperRef.current) {
+      this.scrollParentToChild(this.wrapperRef.current, this.bottomRef.current);
     }
   }
 


### PR DESCRIPTION
Hi there

I have added a public method to the ScrollableFeed component, `scrollToBottom()`, that when called will scroll the wrapper div to the bottom.

This method may be accessed via reference, and when combined with the onScroll prop, can provide the functionality required for a "Scroll to Bottom" button. The Example Application has been updated to showcase this function.

If this PR is to be merged, the demo.gif asset will need updating to reflect the changed Example Application UI.

Thanks
Martin