### PR TITLE
#34 - Update isViewable calculation to correctly determine if a child is visible within its parent

### DIFF
--- a/example/src/index.css
+++ b/example/src/index.css
@@ -5,7 +5,7 @@ body {
 }
 
 .scrollable-wrapper {
-  max-height: 300px;
+  height: 300px;
 }
 
 .dot {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,6 +88,7 @@ class ScrollableFeed extends React.Component<ScrollableFeedProps> {
 
   /**
    * Returns whether a child element is visible within a parent element
+   *
    * @param parent
    * @param child
    * @param epsilon
@@ -100,7 +101,10 @@ class ScrollableFeed extends React.Component<ScrollableFeedProps> {
     const childRect = child.getBoundingClientRect();
 
     const childTopIsViewable = (childRect.top >= parentRect.top);
-    const childBottomIsViewable = (Math.abs(parentRect.top + parent.clientHeight - childRect.top) <= epsilon); //Use epsilon because getBoundingClientRect might return floats https://stackoverflow.com/a/40879359/6316091
+
+    const childOffsetToParentBottom = parentRect.top + parent.clientHeight - childRect.top;
+    const childBottomIsViewable = childOffsetToParentBottom + epsilon >= 0;
+
     return childTopIsViewable && childBottomIsViewable;
   }
 


### PR DESCRIPTION
Hi there

I've made an adjustment to the isViewable calculation used to determine if a child is visible within a parent. This adjustment fixes the issue raised in #34.

Previously, isViewable would only return true if the child was within a specified distance of the parent bottom (the epsilon). This update changes that, and will now return true if the child has a positive offset to (is above) the parent bottom (while still including the epsilon as tolerance)

I have updated the Example Application styles, in commit https://github.com/dizco/react-scrollable-feed/pull/37/commits/650bc75617a41824ce7ec772042db3f4d8e9ba43, to demo this change.

Thanks!